### PR TITLE
Add disk persistence metadata and CPU prefetch for LocalDiskBackend

### DIFF
--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -3,6 +3,7 @@
 from concurrent.futures import Future
 from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
 import asyncio
+import json
 import os
 import threading
 import time
@@ -13,7 +14,13 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    CacheEngineKey,
+    DiskCacheMetadata,
+    STR_DTYPE_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_STR_DTYPE,
+    _lmcache_nvtx_annotate,
+)
 from lmcache.v1.cache_controller.message import KVAdmitMsg, KVEvictMsg
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
@@ -29,6 +36,32 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+_METADATA_SUFFIX = ".meta"
+_METADATA_VERSION = 1
+
+
+def _dtype_to_string(dtype: torch.dtype) -> str:
+    if dtype in TORCH_DTYPE_TO_STR_DTYPE:
+        return TORCH_DTYPE_TO_STR_DTYPE[dtype]
+    dtype_str = str(dtype)
+    if dtype_str.startswith("torch."):
+        dtype_str = dtype_str[len("torch.") :]
+    return dtype_str
+
+
+def _string_to_dtype(dtype_str: Optional[str]) -> Optional[torch.dtype]:
+    if dtype_str is None:
+        return None
+    if dtype_str in STR_DTYPE_TO_TORCH_DTYPE:
+        return STR_DTYPE_TO_TORCH_DTYPE[dtype_str]
+    if dtype_str.startswith("torch."):
+        dtype_str = dtype_str[len("torch.") :]
+    try:
+        return getattr(torch, dtype_str)
+    except AttributeError:
+        logger.warning("Unsupported torch dtype string in metadata: %s", dtype_str)
+        return None
 
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
@@ -148,39 +181,20 @@ class LocalDiskBackend(StorageBackendInterface):
         self.usage = 0
 
         # Disk persistence: repopulate in-memory index from disk if enabled
-        self.local_disk_persistence = getattr(config, "local_disk_persistence", False)
-        self.populate_disk_cache_to_cpu_on_start = getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        self.local_disk_persistence = bool(
+            getattr(config, "local_disk_persistence", False)
+        )
+        self.populate_disk_cache_to_cpu_on_start = bool(
+            getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        )
         if self.local_disk_persistence:
-            logger.info("Local disk persistence enabled. Scanning for existing cache files...")
-            disk_keys = []
-            for fname in os.listdir(self.path):
-                if not fname.endswith(".pt"):
-                    continue
-                # Remove .pt, replace '-' back to '/' for key string
-                key_str = fname[:-3].replace("-", "/")
-                try:
-                    key = CacheEngineKey.from_string(key_str)
-                except Exception as e:
-                    logger.warning(f"Failed to parse cache key from file {fname}: {e}")
-                    continue
-                fpath = os.path.join(self.path, fname)
-                fsize = os.path.getsize(fpath)
-                # Metadata: shape, dtype, fmt are unknown here, will be filled on first access
-                self.dict[key] = DiskCacheMetadata(fpath, fsize, None, None, None, 0)
-                self.current_cache_size += fsize
-                disk_keys.append(key)
-            logger.info(f"Restored {len(self.dict)} disk cache entries from {self.path}.")
-
-            # Optionally prefetch disk cache to CPU
-            if self.populate_disk_cache_to_cpu_on_start and disk_keys:
-                logger.info(f"Prefetching {len(disk_keys)} disk cache entries to CPU memory...")
-                for key in disk_keys:
-                    # This will load the cache into CPU memory (local_cpu_backend)
-                    try:
-                        _ = self.get_blocking(key)
-                    except Exception as e:
-                        logger.warning(f"Failed to prefetch cache for key {key}: {e}")
-                logger.info("Disk cache prefetch to CPU complete.")
+            disk_keys = self._restore_persistent_cache()
+            if (
+                self.populate_disk_cache_to_cpu_on_start
+                and self.use_local_cpu
+                and disk_keys
+            ):
+                self._prefetch_persisted_cache(disk_keys)
 
     def __str__(self):
         return "LocalDiskBackend"
@@ -190,6 +204,169 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
     ) -> str:
         return os.path.join(self.path, key.to_string().replace("/", "-") + ".pt")
+
+    def _metadata_path(self, data_path: str) -> str:
+        return data_path + _METADATA_SUFFIX
+
+    def _write_metadata_file(self, metadata: DiskCacheMetadata) -> None:
+        if metadata.shape is None or metadata.dtype is None:
+            raise ValueError("Metadata must contain shape and dtype to persist to disk")
+
+        fmt_name = metadata.fmt.name if metadata.fmt is not None else None
+        metadata_dict = {
+            "version": _METADATA_VERSION,
+            "size": int(metadata.size),
+            "shape": [int(dim) for dim in metadata.shape],
+            "dtype": _dtype_to_string(metadata.dtype),
+            "fmt": fmt_name,
+        }
+        meta_path = self._metadata_path(metadata.path)
+        tmp_path = meta_path + ".tmp"
+        with open(tmp_path, "w", encoding="utf-8") as f:
+            json.dump(metadata_dict, f)
+        os.replace(tmp_path, meta_path)
+
+    def _read_metadata_from_disk(
+        self, data_path: str
+    ) -> Optional[tuple[int, torch.Size, torch.dtype, Optional[MemoryFormat]]]:
+        meta_path = self._metadata_path(data_path)
+        if not os.path.exists(meta_path):
+            logger.warning("Missing metadata file for persisted cache %s", data_path)
+            return None
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        except Exception as e:
+            logger.warning("Failed to read metadata file %s: %s", meta_path, e)
+            return None
+
+        version = metadata.get("version")
+        if version != _METADATA_VERSION:
+            logger.warning(
+                "Unsupported metadata version %s for %s", version, meta_path
+            )
+            return None
+
+        shape_value = metadata.get("shape")
+        if not isinstance(shape_value, list):
+            logger.warning("Invalid shape metadata for %s: %s", data_path, shape_value)
+            return None
+        try:
+            shape = torch.Size([int(dim) for dim in shape_value])
+        except (TypeError, ValueError) as exc:
+            logger.warning("Failed to parse shape metadata for %s: %s", data_path, exc)
+            return None
+
+        dtype = _string_to_dtype(metadata.get("dtype"))
+        if dtype is None:
+            logger.warning("Invalid dtype metadata for %s", data_path)
+            return None
+
+        fmt_str = metadata.get("fmt")
+        fmt: Optional[MemoryFormat] = None
+        if fmt_str is not None:
+            try:
+                fmt = MemoryFormat[fmt_str]
+            except KeyError:
+                logger.warning(
+                    "Invalid memory format metadata for %s: %s", data_path, fmt_str
+                )
+                fmt = None
+
+        size = metadata.get("size")
+        if size is None:
+            size_int = os.path.getsize(data_path)
+        else:
+            try:
+                size_int = int(size)
+            except (TypeError, ValueError):
+                logger.warning("Invalid size metadata for %s: %s", data_path, size)
+                size_int = os.path.getsize(data_path)
+
+        return size_int, shape, dtype, fmt
+
+    def _remove_metadata_file(self, data_path: str) -> None:
+        meta_path = self._metadata_path(data_path)
+        try:
+            os.remove(meta_path)
+        except FileNotFoundError:
+            return
+        except OSError as e:
+            logger.warning("Failed to remove metadata file %s: %s", meta_path, e)
+
+    def _restore_persistent_cache(self) -> list[CacheEngineKey]:
+        logger.info(
+            "Local disk persistence enabled. Scanning for existing cache files..."
+        )
+        disk_keys: list[CacheEngineKey] = []
+        total_size = 0
+        for entry in sorted(os.listdir(self.path)):
+            if not entry.endswith(".pt"):
+                continue
+            data_path = os.path.join(self.path, entry)
+            if not os.path.isfile(data_path):
+                continue
+            key_str = entry[:-3].replace("-", "/")
+            try:
+                key = CacheEngineKey.from_string(key_str)
+            except Exception as e:
+                logger.warning(
+                    "Failed to parse cache key from file %s: %s", entry, e
+                )
+                continue
+
+            metadata = self._read_metadata_from_disk(data_path)
+            if metadata is None:
+                continue
+            size, shape, dtype, fmt = metadata
+            disk_meta = DiskCacheMetadata(data_path, size, shape, dtype, fmt, 0)
+            self.dict[key] = disk_meta
+            self.cache_policy.update_on_put(key)
+            disk_keys.append(key)
+            total_size += size
+
+        self.current_cache_size = float(total_size)
+        self.usage = total_size
+        self.stats_monitor.update_local_storage_usage(self.usage)
+        if total_size:
+            logger.info(
+                "Restored %d disk cache entries (%.2f MB) from %s.",
+                len(disk_keys),
+                total_size / 1e6,
+                self.path,
+            )
+        else:
+            logger.info("No existing disk cache entries found in %s.", self.path)
+
+        return disk_keys
+
+    def _prefetch_persisted_cache(self, keys: list[CacheEngineKey]) -> None:
+        logger.info(
+            "Prefetching %d disk cache entries to CPU memory...",
+            len(keys),
+        )
+        for key in keys:
+            memory_obj: Optional[MemoryObj] = None
+            try:
+                memory_obj = self.get_blocking(key)
+            except Exception as e:
+                logger.warning("Failed to prefetch cache for key %s: %s", key, e)
+                continue
+
+            if memory_obj is None:
+                logger.warning("Persisted cache for key %s missing on disk", key)
+                continue
+
+            try:
+                self.local_cpu_backend.submit_put_task(key, memory_obj)
+            except Exception as e:
+                logger.warning(
+                    "Failed to populate CPU cache for persisted key %s: %s", key, e
+                )
+            finally:
+                memory_obj.ref_count_down()
+
+        logger.info("Disk cache prefetch to CPU complete.")
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.disk_lock:
@@ -259,8 +436,10 @@ class LocalDiskBackend(StorageBackendInterface):
         # res.result()
 
         os.remove(path)
+        self._remove_metadata_file(path)
 
         if force:
+            self.current_cache_size = max(0.0, self.current_cache_size - size)
             self.cache_policy.update_on_force_evict(key)
             self.disk_lock.release()
 
@@ -283,13 +462,19 @@ class LocalDiskBackend(StorageBackendInterface):
         path = self._key_to_path(key)
 
         has_stored = False
+        metadata_entry = DiskCacheMetadata(path, size, shape, dtype, fmt, False)
         with self.disk_lock:
             # Need to do reinsert to update cache recency
             if key in self.dict:
                 self.dict.pop(key)
                 has_stored = True
 
-            self.dict[key] = DiskCacheMetadata(path, size, shape, dtype, fmt, False)
+            self.dict[key] = metadata_entry
+
+        try:
+            self._write_metadata_file(metadata_entry)
+        except Exception as e:
+            logger.warning("Failed to persist metadata for key %s: %s", key, e)
 
         # push kv admit msg
         if self.lmcache_worker is not None and not has_stored:

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -41,14 +41,18 @@ class MockLMCacheWorker:
         self.messages.append(msg)
 
 
-def create_test_config(disk_path: str, max_disk_size: float = 1.0):
+def create_test_config(
+    disk_path: str, max_disk_size: float = 1.0, **overrides
+):
     """Create a test configuration for LocalDiskBackend."""
-    config = LMCacheEngineConfig.from_defaults(
+    config_kwargs = dict(
         chunk_size=256,
         local_disk=disk_path,
         max_local_disk_size=max_disk_size,
         lmcache_instance_id="test_instance",
     )
+    config_kwargs.update(overrides)
+    config = LMCacheEngineConfig.from_defaults(**config_kwargs)
     return config
 
 
@@ -260,3 +264,103 @@ class TestLocalDiskBackend:
         )
         assert memory_obj is not None
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_disk_persistence_restore_and_prefetch(
+        self, temp_disk_path, async_loop, memory_allocator
+    ):
+        """Disk entries are restored and prefetched to CPU on restart."""
+        config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+            populate_disk_cache_to_cpu_on_start=True,
+        )
+        cpu_backend = LocalCPUBackend(config, memory_allocator=memory_allocator)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(42)
+        memory_obj = create_test_memory_obj()
+        data_path = backend._key_to_path(key)
+        meta_path = data_path + ".meta"
+
+        try:
+            backend.async_save_bytes_to_disk(key, memory_obj)
+            assert os.path.exists(data_path)
+            assert os.path.exists(meta_path)
+        finally:
+            backend.close()
+            cpu_backend.memory_allocator.close()
+
+        restore_config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+            populate_disk_cache_to_cpu_on_start=True,
+        )
+        restore_cpu_backend = LocalCPUBackend(
+            restore_config, memory_allocator=memory_allocator
+        )
+        restored_backend = LocalDiskBackend(
+            config=restore_config,
+            loop=async_loop,
+            local_cpu_backend=restore_cpu_backend,
+            dst_device="cuda",
+        )
+
+        try:
+            assert key in restored_backend.dict
+            restored_meta = restored_backend.dict[key]
+            assert restored_meta.shape == memory_obj.metadata.shape
+            assert restored_meta.dtype == memory_obj.metadata.dtype
+            assert restored_meta.fmt == memory_obj.metadata.fmt
+            assert restored_meta.size == os.path.getsize(data_path)
+            assert restored_backend.current_cache_size == float(restored_meta.size)
+            assert restored_backend.usage == restored_meta.size
+
+            cpu_obj = restored_backend.local_cpu_backend.get_blocking(key)
+            assert cpu_obj is not None
+            assert cpu_obj.metadata.shape == memory_obj.metadata.shape
+            assert cpu_obj.metadata.dtype == memory_obj.metadata.dtype
+            cpu_obj.ref_count_down()
+        finally:
+            restored_backend.close()
+            restore_cpu_backend.memory_allocator.close()
+
+    def test_remove_deletes_metadata_file(
+        self, temp_disk_path, async_loop, memory_allocator
+    ):
+        """Removing an entry deletes both data and metadata files."""
+        config = create_test_config(
+            temp_disk_path,
+            local_disk_persistence=True,
+        )
+        cpu_backend = LocalCPUBackend(config, memory_allocator=memory_allocator)
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(55)
+        memory_obj = create_test_memory_obj()
+        data_path = backend._key_to_path(key)
+        meta_path = data_path + ".meta"
+
+        try:
+            backend.async_save_bytes_to_disk(key, memory_obj)
+            assert os.path.exists(data_path)
+            assert os.path.exists(meta_path)
+
+            removed = backend.remove(key)
+            assert removed
+            assert not os.path.exists(data_path)
+            assert not os.path.exists(meta_path)
+            assert key not in backend.dict
+            assert backend.usage == 0
+        finally:
+            backend.close()
+            cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## Summary
- persist LocalDiskBackend entries by saving per-key metadata sidecar files and restoring them on startup
- prefetch restored disk entries into the CPU cache when configured and keep usage stats in sync
- add regression tests for persistence restore/prefetch and metadata cleanup on removal

## Testing
- pytest tests/v1/storage_backend/test_local_disk_backend.py 