### PR TITLE
Guard metadata file writes behind persistence flag

### DIFF
--- a/lmcache/v1/compute/attention/flash_infer_sparse.py
+++ b/lmcache/v1/compute/attention/flash_infer_sparse.py
@@ -183,6 +183,9 @@ class LMCFlashInferSparseBackend(AttentionInterface):
     for efficient attention computation.
     """
 
+    # Workspace buffer size in bytes (128 MiB)
+    _WORKSPACE_BUFFER_SIZE_BYTES = 128 * 1024 * 1024
+
     def __init__(
         self,
         vllm_attn: Attention,
@@ -194,7 +197,7 @@ class LMCFlashInferSparseBackend(AttentionInterface):
         self.device = torch.device(f"cuda:{idx}")
 
         self.workspace_buffer = torch.empty(
-            128 * 1024 * 1024, dtype=torch.uint8, device="cuda:0"
+            self._WORKSPACE_BUFFER_SIZE_BYTES, dtype=torch.uint8, device=self.device
         )
 
         self.num_qo_heads = self.vllm_attn_impl.num_heads

--- a/lmcache/v1/config.py
+++ b/lmcache/v1/config.py
@@ -84,6 +84,10 @@ _DEPRECATED_CONFIGS = {
 
 # Single configuration definition center - add new config items only here
 _CONFIG_DEFINITIONS: dict[str, dict[str, Any]] = {
+    # Prefetch disk cache to CPU on startup if persistence is enabled
+    "populate_disk_cache_to_cpu_on_start": {"type": bool, "default": True, "env_converter": _to_bool},
+    # Disk persistence for local disk backend
+    "local_disk_persistence": {"type": bool, "default": False, "env_converter": _to_bool},
     # Basic configurations
     "chunk_size": {"type": int, "default": 256, "env_converter": int},
     "local_cpu": {

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -147,6 +147,41 @@ class LocalDiskBackend(StorageBackendInterface):
         self.stats_monitor = LMCStatsMonitor.GetOrCreate()
         self.usage = 0
 
+        # Disk persistence: repopulate in-memory index from disk if enabled
+        self.local_disk_persistence = getattr(config, "local_disk_persistence", False)
+        self.populate_disk_cache_to_cpu_on_start = getattr(config, "populate_disk_cache_to_cpu_on_start", True)
+        if self.local_disk_persistence:
+            logger.info("Local disk persistence enabled. Scanning for existing cache files...")
+            disk_keys = []
+            for fname in os.listdir(self.path):
+                if not fname.endswith(".pt"):
+                    continue
+                # Remove .pt, replace '-' back to '/' for key string
+                key_str = fname[:-3].replace("-", "/")
+                try:
+                    key = CacheEngineKey.from_string(key_str)
+                except Exception as e:
+                    logger.warning(f"Failed to parse cache key from file {fname}: {e}")
+                    continue
+                fpath = os.path.join(self.path, fname)
+                fsize = os.path.getsize(fpath)
+                # Metadata: shape, dtype, fmt are unknown here, will be filled on first access
+                self.dict[key] = DiskCacheMetadata(fpath, fsize, None, None, None, 0)
+                self.current_cache_size += fsize
+                disk_keys.append(key)
+            logger.info(f"Restored {len(self.dict)} disk cache entries from {self.path}.")
+
+            # Optionally prefetch disk cache to CPU
+            if self.populate_disk_cache_to_cpu_on_start and disk_keys:
+                logger.info(f"Prefetching {len(disk_keys)} disk cache entries to CPU memory...")
+                for key in disk_keys:
+                    # This will load the cache into CPU memory (local_cpu_backend)
+                    try:
+                        _ = self.get_blocking(key)
+                    except Exception as e:
+                        logger.warning(f"Failed to prefetch cache for key {key}: {e}")
+                logger.info("Disk cache prefetch to CPU complete.")
+
     def __str__(self):
         return "LocalDiskBackend"
 

--- a/lmcache/v1/storage_backend/local_disk_backend.py
+++ b/lmcache/v1/storage_backend/local_disk_backend.py
@@ -1,8 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 # Standard
 from concurrent.futures import Future
-from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Sequence, Tuple
 import asyncio
+import json
 import os
 import threading
 import time
@@ -13,7 +14,13 @@ import torch
 # First Party
 from lmcache.logging import init_logger
 from lmcache.observability import LMCStatsMonitor
-from lmcache.utils import CacheEngineKey, DiskCacheMetadata, _lmcache_nvtx_annotate
+from lmcache.utils import (
+    CacheEngineKey,
+    DiskCacheMetadata,
+    STR_DTYPE_TO_TORCH_DTYPE,
+    TORCH_DTYPE_TO_STR_DTYPE,
+    _lmcache_nvtx_annotate,
+)
 from lmcache.v1.cache_controller.message import KVAdmitMsg, KVEvictMsg
 from lmcache.v1.config import LMCacheEngineConfig
 from lmcache.v1.memory_management import MemoryFormat, MemoryObj
@@ -29,6 +36,9 @@ if TYPE_CHECKING:
     from lmcache.v1.cache_controller.worker import LMCacheWorker
 
 logger = init_logger(__name__)
+
+
+_METADATA_FILE_SUFFIX = ".meta"
 
 
 # TODO(Jiayi): handle cases where cache is repetitvely prefetched.
@@ -165,10 +175,16 @@ class LocalDiskBackend(StorageBackendInterface):
                     continue
                 fpath = os.path.join(self.path, fname)
                 fsize = os.path.getsize(fpath)
-                # Metadata: shape, dtype, fmt are unknown here, will be filled on first access
-                self.dict[key] = DiskCacheMetadata(fpath, fsize, None, None, None, 0)
+                shape, dtype, fmt = self._read_metadata_file(fpath)
+                if shape is None or dtype is None or fmt is None:
+                    logger.debug(
+                        "Metadata for %s is missing or incomplete; skipping CPU warmup",
+                        key,
+                    )
+                self.dict[key] = DiskCacheMetadata(fpath, fsize, shape, dtype, fmt, 0)
                 self.current_cache_size += fsize
-                disk_keys.append(key)
+                if shape is not None and dtype is not None and fmt is not None:
+                    disk_keys.append(key)
             logger.info(f"Restored {len(self.dict)} disk cache entries from {self.path}.")
 
             # Optionally prefetch disk cache to CPU
@@ -190,6 +206,88 @@ class LocalDiskBackend(StorageBackendInterface):
         key: CacheEngineKey,
     ) -> str:
         return os.path.join(self.path, key.to_string().replace("/", "-") + ".pt")
+
+    def _metadata_file_path(self, data_path: str) -> str:
+        return data_path + _METADATA_FILE_SUFFIX
+
+    def _write_metadata_file(
+        self,
+        data_path: str,
+        shape: Optional[torch.Size],
+        dtype: Optional[torch.dtype],
+        fmt: Optional[MemoryFormat],
+    ) -> None:
+        meta_path = self._metadata_file_path(data_path)
+        metadata: dict[str, Optional[object]] = {
+            "shape": list(shape) if shape is not None else None,
+            "dtype": TORCH_DTYPE_TO_STR_DTYPE.get(dtype) if dtype is not None else None,
+            "fmt": fmt.name if fmt is not None else None,
+        }
+        try:
+            with open(meta_path, "w", encoding="utf-8") as f:
+                json.dump(metadata, f)
+        except Exception as exc:  # pragma: no cover - log unexpected failure
+            logger.warning(
+                "Failed to write metadata file %s: %s", meta_path, exc
+            )
+
+    def _read_metadata_file(
+        self, data_path: str
+    ) -> Tuple[
+        Optional[torch.Size],
+        Optional[torch.dtype],
+        Optional[MemoryFormat],
+    ]:
+        meta_path = self._metadata_file_path(data_path)
+        if not os.path.exists(meta_path):
+            return None, None, None
+
+        try:
+            with open(meta_path, "r", encoding="utf-8") as f:
+                metadata = json.load(f)
+        except Exception as exc:  # pragma: no cover - log unexpected failure
+            logger.warning(
+                "Failed to read metadata file %s: %s", meta_path, exc
+            )
+            return None, None, None
+
+        shape_value = metadata.get("shape")
+        shape = torch.Size(shape_value) if isinstance(shape_value, list) else None
+
+        dtype_str = metadata.get("dtype")
+        dtype = (
+            STR_DTYPE_TO_TORCH_DTYPE.get(dtype_str)
+            if isinstance(dtype_str, str)
+            else None
+        )
+        if isinstance(dtype_str, str) and dtype is None:
+            logger.warning(
+                "Unknown dtype %s in metadata file %s", dtype_str, meta_path
+            )
+
+        fmt_str = metadata.get("fmt")
+        fmt: Optional[MemoryFormat]
+        if isinstance(fmt_str, str):
+            try:
+                fmt = MemoryFormat[fmt_str]
+            except KeyError:
+                logger.warning(
+                    "Unknown memory format %s in metadata file %s", fmt_str, meta_path
+                )
+                fmt = None
+        else:
+            fmt = None
+
+        return shape, dtype, fmt
+
+    def _remove_metadata_file(self, data_path: str) -> None:
+        meta_path = self._metadata_file_path(data_path)
+        try:
+            os.remove(meta_path)
+        except FileNotFoundError:
+            return
+        except OSError as exc:  # pragma: no cover - log unexpected failure
+            logger.warning("Failed to remove metadata file %s: %s", meta_path, exc)
 
     def contains(self, key: CacheEngineKey, pin: bool = False) -> bool:
         with self.disk_lock:
@@ -260,6 +358,9 @@ class LocalDiskBackend(StorageBackendInterface):
 
         os.remove(path)
 
+        if self.local_disk_persistence:
+            self._remove_metadata_file(path)
+
         if force:
             self.cache_policy.update_on_force_evict(key)
             self.disk_lock.release()
@@ -290,6 +391,9 @@ class LocalDiskBackend(StorageBackendInterface):
                 has_stored = True
 
             self.dict[key] = DiskCacheMetadata(path, size, shape, dtype, fmt, False)
+
+        if self.local_disk_persistence:
+            self._write_metadata_file(path, shape, dtype, fmt)
 
         # push kv admit msg
         if self.lmcache_worker is not None and not has_stored:

--- a/tests/v1/storage_backend/test_local_disk_backend.py
+++ b/tests/v1/storage_backend/test_local_disk_backend.py
@@ -260,3 +260,93 @@ class TestLocalDiskBackend:
         )
         assert memory_obj is not None
         local_disk_backend.local_cpu_backend.memory_allocator.close()
+
+    def test_no_metadata_files_when_persistence_disabled(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """Ensure metadata files are not written when persistence is disabled."""
+
+        config = create_test_config(temp_disk_path)
+        config.local_disk_persistence = False
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(10)
+        memory_obj = create_test_memory_obj()
+        expected_shape = memory_obj.metadata.shape
+        expected_dtype = memory_obj.metadata.dtype
+        expected_fmt = memory_obj.metadata.fmt
+
+        backend.disk_worker.insert_put_task(key)
+        backend.async_save_bytes_to_disk(key, memory_obj)
+
+        data_path = backend._key_to_path(key)
+        meta_path = backend._metadata_file_path(data_path)
+
+        assert os.path.exists(data_path)
+        assert not os.path.exists(meta_path)
+
+        # Ensure metadata for the in-memory index is still populated.
+        disk_meta = backend.dict[key]
+        assert disk_meta.shape == expected_shape
+        assert disk_meta.dtype == expected_dtype
+        assert disk_meta.fmt == expected_fmt
+
+        backend.close()
+        local_cpu_backend.memory_allocator.close()
+
+    def test_metadata_restored_with_persistence_enabled(
+        self, temp_disk_path, async_loop, local_cpu_backend
+    ):
+        """Metadata should round-trip when disk persistence is enabled."""
+
+        config = create_test_config(temp_disk_path)
+        config.local_disk_persistence = True
+        config.populate_disk_cache_to_cpu_on_start = False
+        backend = LocalDiskBackend(
+            config=config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda",
+        )
+
+        key = create_test_key(11)
+        memory_obj = create_test_memory_obj()
+        expected_shape = memory_obj.metadata.shape
+        expected_dtype = memory_obj.metadata.dtype
+        expected_fmt = memory_obj.metadata.fmt
+
+        backend.disk_worker.insert_put_task(key)
+        backend.async_save_bytes_to_disk(key, memory_obj)
+
+        data_path = backend._key_to_path(key)
+        meta_path = backend._metadata_file_path(data_path)
+
+        assert os.path.exists(data_path)
+        assert os.path.exists(meta_path)
+
+        backend.close()
+
+        # Create a fresh backend using the same disk path to validate restore.
+        reload_config = create_test_config(temp_disk_path)
+        reload_config.local_disk_persistence = True
+        reload_config.populate_disk_cache_to_cpu_on_start = False
+        backend_reloaded = LocalDiskBackend(
+            config=reload_config,
+            loop=async_loop,
+            local_cpu_backend=local_cpu_backend,
+            dst_device="cuda",
+        )
+
+        assert key in backend_reloaded.dict
+        disk_meta = backend_reloaded.dict[key]
+        assert disk_meta.shape == expected_shape
+        assert disk_meta.dtype == expected_dtype
+        assert disk_meta.fmt == expected_fmt
+
+        backend_reloaded.close()
+        local_cpu_backend.memory_allocator.close()


### PR DESCRIPTION
## Summary
- guard LocalDiskBackend metadata serialization behind the local_disk_persistence flag and persist metadata alongside disk entries
- hydrate cached metadata from .meta files on startup and clean them up when evicting entries
- add regression tests covering persistence disabled/enabled scenarios for the disk backend

## Testing
- pytest tests/v1/storage_backend/test_local_disk_backend.py *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68ced8f3d1a08332825832b0e2b24348